### PR TITLE
docs: add Canadian AI jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 This repository is a comprehensive list of AI/ML & Data Science jobs for college students in search of **internships** or **new graduate** positions. The positions are updated daily, and we prioritize jobs posted within the last 120 days.
 
+Canada-specific companion resource: [Hanzilla Jobs - Data, AI & ML roles](https://jobs.hanzilla.co/categories/data-ml/) is a free daily-updated board for Canadian students and recent grads looking for AI/ML, data, internship, co-op, new-grad, junior, and entry-level roles across Canada.
+
 ### USA Positions :eagle:
 - [Internships :books:](/) - **186** available ([FAANG+](#faang), [Quant](#quant), [Other](#other))
 - [New Graduate :mortar_board:](/NEW_GRAD_USA.md) - **224** available ([FAANG+](/NEW_GRAD_USA.md#faang), [Quant](/NEW_GRAD_USA.md#quant), [Other](/NEW_GRAD_USA.md#other))


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a Canada-specific companion resource for AI/ML/data roles
- Links directly to the Canada data/AI/ML category page for students and recent grads looking for internships, co-ops, new-grad, junior, and entry-level roles

## Why
This repo is useful for AI/ML and data roles globally; Hanzilla is a free daily-updated Canadian student/recent-grad board, so it may help Canadian readers looking for local opportunities across Canada.

## Test plan
- Markdown-only README change
- `git diff --check`
